### PR TITLE
Some terms change, and WithdrawBalance method modification

### DIFF
--- a/actors/builtin/methods.go
+++ b/actors/builtin/methods.go
@@ -103,7 +103,7 @@ var MethodsMiner = struct {
 	PreCommitSectorBatch     abi.MethodNum
 	ProveCommitAggregate     abi.MethodNum
 	ProveReplicaUpdates      abi.MethodNum
-	ChangeBeneficiaryInfo    abi.MethodNum
+	ChangeBeneficiary        abi.MethodNum
 }{MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28}
 
 var MethodsVerifiedRegistry = struct {

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1972,7 +1972,7 @@ func (a Actor) ReportConsensusFault(rt Runtime, params *ReportConsensusFaultPara
 type WithdrawBalanceParams = miner0.WithdrawBalanceParams
 
 // Attempt to withdraw the specified amount from the miner's available balance.
-// Only beneficiary key has permission to withdraw.
+// Only beneficiary key and owner key have permission to withdraw.
 // If less than the specified amount is available, yields the entire available balance.
 // Returns the amount withdrawn.
 func (a Actor) WithdrawBalance(rt Runtime, params *WithdrawBalanceParams) *abi.TokenAmount {
@@ -1985,13 +1985,13 @@ func (a Actor) WithdrawBalance(rt Runtime, params *WithdrawBalanceParams) *abi.T
 	feeToBurn := big.Zero()
 	availableBalance := big.Zero()
 	amountWithdrawn := big.Zero()
-	var receiver addr.Address
+
 	rt.StateTransaction(&st, func() {
 		var err error
 		info = getMinerInfo(rt, &st)
 		// Only the owner/beneficiary is allowed to withdraw the balance as it belongs to/is controlled by the owner
 		// and not the worker.
-		rt.ValidateImmediateCallerIs(info.Owner, info.BeneficiaryAddress)
+		rt.ValidateImmediateCallerIs(info.Owner, info.Beneficiary)
 		// Ensure we don't have any pending terminations.
 		if count, err := st.EarlyTerminations.Count(); err != nil {
 			builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to count early terminations")
@@ -2017,17 +2017,15 @@ func (a Actor) WithdrawBalance(rt Runtime, params *WithdrawBalanceParams) *abi.T
 		// and repay fee debt now.
 		feeToBurn = RepayDebtsOrAbort(rt, &st)
 
-		if info.BeneficiaryAddress == addr.Undef || info.Owner == info.BeneficiaryAddress {
-			receiver = info.Owner
+		// To get the actual amount to be withdrawed
+		if info.Beneficiary == info.Owner {
 			amountWithdrawn = big.Min(availableBalance, params.AmountRequested)
 		} else {
-			receiver = info.BeneficiaryAddress
-			builtin.RequireState(rt, !info.BeneficiaryInfo.IsUsedUp(), "beneficiary(%s) %d use up quota", info.BeneficiaryAddress)
-			builtin.RequireState(rt, !info.BeneficiaryInfo.IsExpire(rt.CurrEpoch()), "beneficiary(%s) %d have expired at epoch %d", info.BeneficiaryAddress, info.BeneficiaryInfo.ExpireDate, rt.CurrEpoch())
+			builtin.RequireState(rt, !info.BeneficiaryInfo.IsUsedUp(), "beneficiary(%s) %d use up quota", info.Beneficiary)
+			builtin.RequireState(rt, !info.BeneficiaryInfo.IsExpire(rt.CurrEpoch()), "beneficiary(%s) %d have expired at epoch %d", info.Beneficiary, info.BeneficiaryInfo.ExpireDate, rt.CurrEpoch())
 			amountWithdrawn = big.Min(big.Min(availableBalance, params.AmountRequested), info.BeneficiaryInfo.Available())
 		}
 
-		info.BeneficiaryInfo.UsedQuota = big.Add(info.BeneficiaryInfo.UsedQuota, amountWithdrawn)
 		err = st.SaveInfo(adt.AsStore(rt), info)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "could not save miner info")
 	})
@@ -2036,8 +2034,12 @@ func (a Actor) WithdrawBalance(rt Runtime, params *WithdrawBalanceParams) *abi.T
 	builtin.RequireState(rt, amountWithdrawn.LessThanEqual(availableBalance), "amount to withdraw %v < available %v", amountWithdrawn, availableBalance)
 
 	if amountWithdrawn.GreaterThan(abi.NewTokenAmount(0)) {
-		code := rt.Send(receiver, builtin.MethodSend, nil, amountWithdrawn, &builtin.Discard{})
+		code := rt.Send(info.Beneficiary, builtin.MethodSend, nil, amountWithdrawn, &builtin.Discard{})
 		builtin.RequireSuccess(rt, code, "failed to withdraw balance")
+
+		if info.Beneficiary != info.Owner {
+			info.BeneficiaryInfo.UsedQuota = big.Add(info.BeneficiaryInfo.UsedQuota, amountWithdrawn)
+		}
 	}
 
 	burnFunds(rt, feeToBurn, BurnMethodWithdrawBalance)
@@ -3151,13 +3153,13 @@ func (a Actor) ChangeBeneficiary(rt Runtime, params *ChangeBeneficiaryParams) *a
 
 		if rt.Caller() == info.Owner {
 			rt.ValidateImmediateCallerIs(info.Owner)
-			if info.BeneficiaryAddress != info.Owner && info.BeneficiaryInfo.Effective(rt.CurrEpoch()) {
+			if info.Beneficiary != info.Owner && info.BeneficiaryInfo.Effective(rt.CurrEpoch()) {
 				checkNewBeneficialParam(rt, params)
 				info.PendingBeneficiaryInfo = &PendingBeneficiaryChange{
 					NewBeneficiary: newBeneficiary,
 					NewQuota:       params.NewQuota,
 					NewExpireDate:  params.NewExpireDate,
-					NextApprover:   info.BeneficiaryAddress,
+					NextApprover:   info.Beneficiary,
 				}
 			} else {
 				if newBeneficiary != info.Owner {
@@ -3169,7 +3171,7 @@ func (a Actor) ChangeBeneficiary(rt Runtime, params *ChangeBeneficiaryParams) *a
 						NextApprover:   newBeneficiary,
 					}
 				} else {
-					info.BeneficiaryAddress = newBeneficiary
+					info.Beneficiary = newBeneficiary
 					info.BeneficiaryInfo = BeneficiaryInfo{
 						Quota:      big.Zero(),
 						ExpireDate: 0,
@@ -3190,11 +3192,11 @@ func (a Actor) ChangeBeneficiary(rt Runtime, params *ChangeBeneficiaryParams) *a
 				info.PendingBeneficiaryInfo.NextApprover = newBeneficiary
 			} else {
 				usedQutota := info.BeneficiaryInfo.UsedQuota
-				if newBeneficiary != info.BeneficiaryAddress {
+				if newBeneficiary != info.Beneficiary {
 					//reset to zero for different address
 					usedQutota = big.Zero()
 				}
-				info.BeneficiaryAddress = newBeneficiary
+				info.Beneficiary = newBeneficiary
 				info.BeneficiaryInfo = BeneficiaryInfo{
 					Quota:      info.PendingBeneficiaryInfo.NewQuota,
 					ExpireDate: info.PendingBeneficiaryInfo.NewExpireDate,

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"math"
+
 	addr "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/go-state-types/abi"
@@ -20,7 +22,6 @@ import (
 	cid "github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
-	"math"
 
 	"github.com/filecoin-project/specs-actors/v7/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v7/actors/builtin/market"
@@ -77,7 +78,7 @@ func (a Actor) Exports() []interface{} {
 		25:                        a.PreCommitSectorBatch,
 		26:                        a.ProveCommitAggregate,
 		27:                        a.ProveReplicaUpdates,
-		28:                        a.ChangeBeneficiaryInfo,
+		28:                        a.ChangeBeneficiary,
 	}
 }
 
@@ -3139,8 +3140,8 @@ func checkNewBeneficialParam(rt Runtime, params *ChangeBeneficiaryParams) {
 	}
 }
 
-// ChangeBeneficiaryInfo proposal/approve beneficiary change
-func (a Actor) ChangeBeneficiaryInfo(rt Runtime, params *ChangeBeneficiaryParams) *abi.EmptyValue {
+// ChangeBeneficiary proposal/approve beneficiary change
+func (a Actor) ChangeBeneficiary(rt Runtime, params *ChangeBeneficiaryParams) *abi.EmptyValue {
 	newBeneficiary, err := builtin.ResolveToIDAddr(rt, params.NewBeneficiary)
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to resolve address %v", params.NewBeneficiary)
 

--- a/actors/builtin/miner/miner_state.go
+++ b/actors/builtin/miner/miner_state.go
@@ -129,7 +129,7 @@ type MinerInfo struct {
 
 	PendingWorkerKey *WorkerKeyChange
 
-	BeneficiaryAddress     addr.Address
+	Beneficiary            addr.Address
 	BeneficiaryInfo        BeneficiaryInfo
 	PendingBeneficiaryInfo *PendingBeneficiaryChange
 
@@ -281,10 +281,10 @@ func ConstructMinerInfo(owner, worker addr.Address, controlAddrs []addr.Address,
 	}
 
 	return &MinerInfo{
-		Owner:              owner,
-		Worker:             worker,
-		ControlAddresses:   controlAddrs,
-		BeneficiaryAddress: owner,
+		Owner:            owner,
+		Worker:           worker,
+		ControlAddresses: controlAddrs,
+		Beneficiary:      owner,
 		BeneficiaryInfo: BeneficiaryInfo{
 			Quota:      abi.TokenAmount{},
 			ExpireDate: 0,

--- a/actors/builtin/miner/miner_state_test.go
+++ b/actors/builtin/miner/miner_state_test.go
@@ -977,9 +977,9 @@ func constructStateHarness(t *testing.T, periodBoundary abi.ChainEpoch) *stateHa
 	require.NoError(t, err)
 
 	info := miner.MinerInfo{
-		Owner:              owner,
-		Worker:             worker,
-		BeneficiaryAddress: owner,
+		Owner:       owner,
+		Worker:      worker,
+		Beneficiary: owner,
 		BeneficiaryInfo: miner.BeneficiaryInfo{
 			Quota:      abi.TokenAmount{},
 			ExpireDate: 0,

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -2729,7 +2729,7 @@ func TestChangeBeneficiary(t *testing.T) {
 		info = actor.getInfo(rt)
 		require.EqualValues(t, expireDate, info.BeneficiaryInfo.ExpireDate)
 		require.EqualValues(t, quota, info.BeneficiaryInfo.Quota)
-		require.EqualValues(t, newBeneficiaryId, info.BeneficiaryAddress)
+		require.EqualValues(t, newBeneficiaryId, info.Beneficiary)
 	})
 
 	t.Run("successfully change back to owner address while used up quota, should work immediately", func(t *testing.T) {
@@ -2749,7 +2749,7 @@ func TestChangeBeneficiary(t *testing.T) {
 
 		// assert change has been made in state
 		info := actor.getInfo(rt)
-		require.EqualValues(t, actor.owner, info.BeneficiaryAddress)
+		require.EqualValues(t, actor.owner, info.Beneficiary)
 		require.EqualValues(t, big.Zero(), info.BeneficiaryInfo.Quota)
 		require.EqualValues(t, 0, info.BeneficiaryInfo.ExpireDate)
 		require.True(t, info.PendingBeneficiaryInfo == nil)
@@ -2771,7 +2771,7 @@ func TestChangeBeneficiary(t *testing.T) {
 
 		// assert change has been made in state
 		info := actor.getInfo(rt)
-		require.EqualValues(t, actor.owner, info.BeneficiaryAddress)
+		require.EqualValues(t, actor.owner, info.Beneficiary)
 		require.True(t, info.PendingBeneficiaryInfo == nil)
 	})
 
@@ -2804,7 +2804,7 @@ func TestChangeBeneficiary(t *testing.T) {
 		actor.changeBeneficiary(rt, secondBeneficiary, secondBeneficiary, anotherQuota, anotherExpireDate)
 
 		info = actor.getInfo(rt)
-		require.EqualValues(t, secondBeneficiaryId, info.BeneficiaryAddress)
+		require.EqualValues(t, secondBeneficiaryId, info.Beneficiary)
 		require.EqualValues(t, anotherQuota, info.BeneficiaryInfo.Quota)
 		require.EqualValues(t, anotherExpireDate, info.BeneficiaryInfo.ExpireDate)
 		require.EqualValues(t, big.Zero(), info.BeneficiaryInfo.UsedQuota)
@@ -2835,7 +2835,7 @@ func TestChangeBeneficiary(t *testing.T) {
 
 		// assert change has been made in state
 		info = actor.getInfo(rt)
-		require.EqualValues(t, newBeneficiaryId, info.BeneficiaryAddress)
+		require.EqualValues(t, newBeneficiaryId, info.Beneficiary)
 		require.EqualValues(t, quota, info.BeneficiaryInfo.UsedQuota)
 		require.EqualValues(t, increaseQuota, info.BeneficiaryInfo.Quota)
 	})
@@ -2873,7 +2873,7 @@ func TestChangeBeneficiary(t *testing.T) {
 		//confirm by new beneficiary address and worked
 		actor.changeBeneficiary(rt, secondBeneficiary, secondBeneficiary, sencondQuota, sencondExpireDate)
 		info = actor.getInfo(rt)
-		require.EqualValues(t, secondBeneficiaryId, info.BeneficiaryAddress)
+		require.EqualValues(t, secondBeneficiaryId, info.Beneficiary)
 		require.EqualValues(t, sencondQuota, info.BeneficiaryInfo.Quota)
 		require.EqualValues(t, sencondExpireDate, info.BeneficiaryInfo.ExpireDate)
 		require.EqualValues(t, big.Zero(), info.BeneficiaryInfo.UsedQuota)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -2690,7 +2690,7 @@ func TestChangeMultiAddrs(t *testing.T) {
 	})
 }
 
-func TestChangeBeneficiaryInfo(t *testing.T) {
+func TestChangeBeneficiary(t *testing.T) {
 	periodOffset := abi.ChainEpoch(100)
 	newBeneficiaryId := tutil.NewIDAddr(t, 999)
 	newBeneficiary := tutil.NewBLSAddr(t, 100)
@@ -3931,12 +3931,12 @@ func (h *actorHarness) changeOwnerToNewBeneficiary(rt *mock.Runtime, beneficiary
 		NewQuota:       beneficiary.Quota,
 		NewExpireDate:  beneficiary.ExpireDate,
 	}
-	rt.Call(h.a.ChangeBeneficiaryInfo, param)
+	rt.Call(h.a.ChangeBeneficiary, param)
 	rt.Verify()
 
 	rt.ExpectValidateCallerAddr(beneficiaryIdAddr)
 	rt.SetCaller(beneficiaryIdAddr, builtin.AccountActorCodeID)
-	rt.Call(h.a.ChangeBeneficiaryInfo, param)
+	rt.Call(h.a.ChangeBeneficiary, param)
 	rt.Verify()
 }
 
@@ -4132,7 +4132,7 @@ func (h *actorHarness) changeBeneficiary(rt *mock.Runtime, expectCaller addr.Add
 
 	rt.ExpectValidateCallerAddr(callerId)
 	rt.SetCaller(callerId, builtin.AccountActorCodeID)
-	rt.Call(h.a.ChangeBeneficiaryInfo, param)
+	rt.Call(h.a.ChangeBeneficiary, param)
 	rt.Verify()
 }
 

--- a/actors/states/election_test.go
+++ b/actors/states/election_test.go
@@ -140,9 +140,9 @@ func constructMinerState(ctx context.Context, t *testing.T, store adt.Store, own
 	require.NoError(t, err)
 
 	info := miner.MinerInfo{
-		Owner:              owner,
-		Worker:             owner,
-		BeneficiaryAddress: owner,
+		Owner:       owner,
+		Worker:      owner,
+		Beneficiary: owner,
 		BeneficiaryInfo: miner.BeneficiaryInfo{
 			Quota:      abi.TokenAmount{},
 			ExpireDate: 0,


### PR DESCRIPTION
1. Change the terms according to the FIP draft. We need to stick on the document. 
2. WithdrawBalance method reviewed, and make some changes for: 
     - Beneficiary is a role, there will be always an address to be beneficiary. It will never be undef
     - Only when Beneficiary share the same address of owner, the UsedQuota need to be accumulated. 